### PR TITLE
Fix 6x6 Sudoku Shuffling

### DIFF
--- a/scripts/data/generate_sudoku_data.py
+++ b/scripts/data/generate_sudoku_data.py
@@ -84,7 +84,7 @@ def shuffle_sudoku(board: np.ndarray, solution: np.ndarray, grid_size: int, rng:
     # Apply transformations using advanced indexing
     transpose_flag = rng.random() < 0.5
     
-    if transpose_flag:
+    if transpose_flag and grid_size in [4, 9]:
         new_board = digit_map[board.T[row_perm][:, col_perm]]
         new_solution = digit_map[solution.T[row_perm][:, col_perm]]
     else:


### PR DESCRIPTION
The 6x6 sudoku generation script generated invalid grids. This is due to the transpose operation in the shuffling function, because the transpose of a valid 6x6 sudoku is not valid in general. This caused nearly half of the sample in the 6x6 medium sudoku dataset to be invalid.